### PR TITLE
create alias functionality added

### DIFF
--- a/lib/mixpanel.ex
+++ b/lib/mixpanel.ex
@@ -99,4 +99,25 @@ defmodule Mixpanel do
 
   defp convert_ip({a, b, c, d}), do: "#{a}.#{b}.#{c}.#{d}"
   defp convert_ip(ip), do: ip
+
+  @doc """
+  Creates an alias for a distinct ID, merging two profiles.
+  Mixpanel supports adding an alias to a distinct id. An alias is a new
+  value that will be interpreted by Mixpanel as an existing value. That
+  means that you can send messages to Mixpanel using the new value, and
+  Mixpanel will continue to use the old value for calculating funnels and
+  retention reports, or applying updates to user profiles.
+
+  ## Arguments
+
+  * `alias_id` - The new additional ID of the user.
+  * `distinct_id` - The current ID of the user.
+
+  """
+  @spec create_alias(String.t(), String.t()) :: :ok
+  def create_alias(alias_id, distinct_id) do
+    Mixpanel.Client.create_alias(alias_id, distinct_id)
+
+    :ok
+  end
 end

--- a/lib/mixpanel/client.ex
+++ b/lib/mixpanel/client.ex
@@ -37,7 +37,7 @@ defmodule Mixpanel.Client do
   end
 
   @doc """
-  Creates an alias for a Mixpanel user.
+  Creates an alias for a user profile.
 
   See `Mixpanel.create_alias/2`.
   """

--- a/lib/mixpanel/client.ex
+++ b/lib/mixpanel/client.ex
@@ -10,6 +10,7 @@ defmodule Mixpanel.Client do
 
   @track_endpoint "https://api.mixpanel.com/track"
   @engage_endpoint "https://api.mixpanel.com/engage"
+  @alias_endpoint "https://api.mixpanel.com/track#identity-create-alias"
 
   def start_link(config, opts \\ []) do
     GenServer.start_link(__MODULE__, {:ok, config}, opts)
@@ -33,6 +34,16 @@ defmodule Mixpanel.Client do
   @spec engage(Map.t()) :: :ok
   def engage(event) do
     GenServer.cast(__MODULE__, {:engage, event})
+  end
+
+  @doc """
+  Creates an alias for a Mixpanel user.
+
+  See `Mixpanel.create_alias/2`.
+  """
+  @spec create_alias(String.t(), String.t()) :: :ok
+  def create_alias(alias, distinct_id) do
+    GenServer.cast(__MODULE__, {:create_alias, alias, distinct_id})
   end
 
   def init({:ok, config}) do
@@ -79,6 +90,35 @@ defmodule Mixpanel.Client do
 
     {:noreply, state}
   end
+
+  def handle_cast({:create_alias, alias, distinct_id}, %{token: token, active: true} = state) do
+    data =
+      %{
+        event: "$create_alias",
+        properties: %{
+          token: token,
+          alias: alias,
+          distinct_id: distinct_id
+        }
+      }
+      |> Poison.encode!()
+      |> :base64.encode()
+
+    case HTTPoison.post(@alias_endpoint, "data=#{data}", [{"Content-Type", "application/x-www-form-urlencoded"}]) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: "1"}} ->
+        :ok
+
+      other ->
+        Logger.warn(
+          "Problem creating Mixpanel alias: alias=#{inspect(alias)}, distinct_id=#{inspect(distinct_id)} Got: #{
+            inspect(other)
+          }"
+        )
+    end
+
+    {:noreply, state}
+  end
+
 
   # No events submitted when env configuration is set to false.
   def handle_cast(_request, %{active: false} = state) do


### PR DESCRIPTION
Hi there!

I've added Mixpanel's `Create Alias` functionality to this project. This feature allows to create an  alias for a distinct Mixpanel user ID, which can be useful for tracking the same user across different devices or after they've changed their identifying details.

I've tested this locally, and it's working as expected. Please let me know if there are any changes you'd like me to make or if you have any questions about the implementation.

Thanks for considering my contribution!