### PR TITLE
Suggest putting application in `extra_applications`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ And ensure that `mixpanel_api_ex` is started before your application:
 
 ```elixir
 def application do
-  [applications: [:mixpanel_api_ex, :my_app]]
+  [
+    ...
+    extra_applications: [:mixpanel_api_ex, ...]
+  ]
 end
 ```
 


### PR DESCRIPTION
According to [the docs](https://hexdocs.pm/mix/1.12/Mix.Tasks.Compile.App.html), `extra_applications` starts applications before your app.

The problem with the current proposal in the README is that if you set `applications` then you don't get your `extra_applications` (at least, I was getting lots of errors about applications not being started in my tests)